### PR TITLE
set :db.part/user as default partition with fixtures

### DIFF
--- a/src/toolbelt/datomic/test.clj
+++ b/src/toolbelt/datomic/test.clj
@@ -1,6 +1,7 @@
 (ns toolbelt.datomic.test
   (:require [datomic.api :as d]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [toolbelt.datomic.schema :as tds]))
 
 
 ;; ==============================================================================
@@ -42,10 +43,11 @@
    (conn-fixture identity))
   ([txn-fn]
    (fn [test-fn]
-     (with-conn r
-       (binding [*conn* r]
-         (txn-fn r)
-         (test-fn))))))
+     (tds/with-partition :db.part/user
+       (with-conn r
+         (binding [*conn* r]
+           (txn-fn r)
+           (test-fn)))))))
 
 
 (defn conn


### PR DESCRIPTION
## Context
Tests were failing when the server was run with `(go)`. This PR fixes the issue by setting the default partition for all fixture connections to :db.part/user.

## Relevant Tasks
[fix annoying fixtures/partition issue](https://app.asana.com/0/515455373234662/946810838878727)

## Changes
set :db.part/user as default partition with fixtures

