### PR TITLE
CDM-26: Update compile-schema to accept an input function to read schemas in a namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -8,5 +8,10 @@
                  [org.clojure/tools.macro "0.1.2"]
                  [com.datomic/datomic-free "0.9.5544" :scope "provided"]
                  [io.rkn/conformity "0.5.1"]]
-  :deploy-repositories [["releases" {:url   "https://clojars.org/repo"
-                                     :creds :gpg}]])
+  :plugins [[s3-wagon-private "1.2.0"]]
+  :deploy-repositories {"releases"  {:url        "s3://starjars/releases"
+                                     :username   :env/aws_access_key
+                                     :passphrase :env/aws_secret_key}
+                        "snapshots" {:url        "s3://starjars/snapshots"
+                                     :username   :env/aws_access_key
+                                     :passphrase :env/aws_secret_key}})

--- a/src/toolbelt/datomic/schema.clj
+++ b/src/toolbelt/datomic/schema.clj
@@ -93,8 +93,9 @@
 
 (defn compile-schema
   "Compile all schemas in `namespace` into a map of conformity norms."
-  [namespace]
-  (let [norms (->> (read-schema namespace)
+  [namespace & {:keys [read-schema-fn]
+                :or   {read-schema-fn read-schema}}]
+  (let [norms (->> (read-schema-fn namespace)
                    (map second)
                    (assemble-norms))]
     (assert (s/valid? ::norms norms) (s/explain-str ::norms norms))


### PR DESCRIPTION
## Context 
Updating `compile-schema` to take an input function to read schemas in a namespace to be able to include support for feature flagging schema declarations in https://github.com/starcity-properties/blueprints/pull/221
And updating the repositories to deploy to starjars and have tests work

## Testing done
Testing has been done as part of https://github.com/starcity-properties/blueprints/pull/221